### PR TITLE
Fix typo in error page styles

### DIFF
--- a/src/css/error-page.css
+++ b/src/css/error-page.css
@@ -20,7 +20,7 @@
   color: #000;
 }
 
-.sub-massage {
+.sub-message {
   font: 400 32px "Roboto", sans-serif;
   letter-spacing: 0em;
   color: #000;


### PR DESCRIPTION
## Summary
- correct selector typo in `error-page.css`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f516ec6d883238e6e44a4c3f3a11a